### PR TITLE
Reduces the font size on article and topic titles

### DIFF
--- a/styles/_concept.scss
+++ b/styles/_concept.scss
@@ -26,7 +26,7 @@
 }
 
 .topic-card__concept-article {
-	@include oTypographySans($scale: 2);
+	@include oTypographySans($scale: 1);
 	@include oTypographyPadding($top: 0, $bottom: 3);
 	margin: 8px 0 0;
 	padding-left: 0;

--- a/styles/_myft-card.scss
+++ b/styles/_myft-card.scss
@@ -18,7 +18,7 @@
 }
 
 .topic-card__myft-title {
-	@include oTypographySansBold($scale: 2, $progressive: true);
+	@include oTypographySansBold($scale: 1, $progressive: true);
 	color: getColor('black');
 	flex: 1 1 auto;
 	padding-right: 10px;


### PR DESCRIPTION
**Before**
<img width="993" alt="screen shot 2018-01-31 at 12 03 27" src="https://user-images.githubusercontent.com/524573/35622193-dd45c710-067e-11e8-805a-371ea441177a.png">

**After**
<img width="993" alt="screen shot 2018-01-31 at 12 03 15" src="https://user-images.githubusercontent.com/524573/35622200-e386d4ca-067e-11e8-8a1e-770b889ddd9f.png">
