### PR TITLE
Bump n-myft-ui to v11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "o-grid": "^4.2.3",
     "o-icons": ">=4.0.0 <6",
     "o-tracking": "^1.1.15",
-    "n-myft-ui": "^10.0.0",
+    "n-myft-ui": "^11.0.0",
     "n-image": "^5.0.0",
     "n-ui-foundations": "^3.0.0-beta"
   }


### PR DESCRIPTION
the new `n-myft-ui` has a change that would make the follow buttons completely broken if it were not for a change to `next-myft-proxy`, so it's a major bump

and because of that, this will also mean a major `n-topic-card` bump. i regret being born.