### PR TITLE
Remove nUiMyftCommon styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ n-topic-card requires at least the following data:
 
 Please view the source for more information.
 
+Make sure that when used, myFT styles are included in the head stylesheet of the app. If not, necessary styles can be included by adding this code:
+```
+@import 'n-myft-ui/myft-common/main';
+@include nUiMyftCommon();
+```
+
 ## Extra data
 
 `responsive-grids` handles scenarios where you want particular cards to be hidden at certain breakpoints. For example, on the home page only 3 myFT concept cards are shown between the medium and large breakpoints.  This decorator requires the data item `show` with the settings in an object e.g. `{ default: true, M: false, XL: true }`.

--- a/main.scss
+++ b/main.scss
@@ -1,9 +1,6 @@
 @import 'n-myft-ui/myft/main';
-@import 'n-myft-ui/myft-common/main';
 @import 'n-image/main';
 @import "o-icons/main";
 @import './styles/myft-card';
 @import './styles/concept';
 @import './styles/classifier';
-
-@include nUiMyftCommon();

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,6 @@
 @import 'n-myft-ui/myft/main';
 @import 'n-image/main';
-@import "o-icons/main";
+@import 'o-icons/main';
 @import './styles/myft-card';
 @import './styles/concept';
 @import './styles/classifier';

--- a/templates/concept.html
+++ b/templates/concept.html
@@ -85,7 +85,9 @@
 			{{#unless items.length }}
 			<p class="topic-card__excess">0 stories</p>
 			{{/unless}}
-			<div class="topic-card__myft-btn topic-card__myft-btn--alerts">{{> n-myft-ui/components/instant-alert/instant-alert conceptId=id name=name extraClasses="topic-card__concept-instant" }}</div>
+			<div class="topic-card__myft-btn topic-card__myft-btn--alerts">
+				{{> n-myft-ui/components/instant-alert/instant-alert conceptId=id name=name }}
+			</div>
 			{{#if ../isFollowing}}
 				{{> n-myft-ui/components/pin-button/pin-button}}
 			{{/if}}


### PR DESCRIPTION
## What was done
Do not include `nUiMyftCommon` mixin' styles 

## Why
To avoid de-duping of myFT styles that are to be included in the 'head' stylesheet of the apps.
Better fix to replace temporary patches: 
- https://github.com/Financial-Times/next-front-page/pull/1896
- https://github.com/Financial-Times/next-myft-page/pull/1827

## Notes
 - Components are being adjusted accordingly (PRs are linked)
 - feature will be released as the next version to make sure that no app breaks