### PR TITLE
Remove the long since killed tagToFollow

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -9,7 +9,6 @@ const urls = ['http://localhost:5005/'];
 
 const config = {
 	defaults: {
-		page: {},
 		timeout: 50000,
 		hideElements: 'iframe[src*=google],iframe[src*=proxy]',
 		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
@@ -19,8 +18,10 @@ const config = {
 
 for (let viewport of viewports) {
 	for (let url of urls) {
-		url.viewport = viewport;
-		config.urls.push(url);
+		config.urls.push({
+			url,
+			viewport
+		});
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-topic-card#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "^1.8.5",
+    "@financial-times/n-gage": "^2.0.4",
     "@financial-times/n-internal-tool": "^1.2.3",
     "bower": "^1.7.9",
     "chai": "^3.5.0",
@@ -23,7 +23,7 @@
     "mocha": "^3.1.2",
     "node-sass": "^4.5.3",
     "npm-prepublish": "^1.2.2",
-    "pa11y-ci": "^0.4.0"
+    "pa11y-ci": "^2.1.1"
   },
   "scripts": {
     "precommit": "node_modules/.bin/secret-squirrel",

--- a/templates/concept.html
+++ b/templates/concept.html
@@ -28,7 +28,7 @@
 						<li class="topic-card__concept-article {{#ifEquals hasBeenRead true}}topic-card__concept-article--read{{/ifEquals}}{{#ifEquals type 'video'}} topic-card__concept-article--video{{/ifEquals}}">
 							<a
 								class="topic-card__concept-article-link"
-								href="{{url}}{{#unless ../isFollowing}}?tagToFollow={{../conceptId}}{{/unless}}{{../referrerTracking}}"
+								href="{{url}}{{../referrerTracking}}"
 								data-trackable="article"
 							>
 								<span class="topic-card__classifier-gap">


### PR DESCRIPTION
In essence this was adding a `?tagToFollow=` querystring to the article URLs, which no longer does anything.

It looks like this was killed back in January 2017 with https://github.com/Financial-Times/next-article/pull/1788

This may well be reducing cache hit ratio so worth cleaning up.

 🐿 v2.5.16