### PR TITLE
Add data-concept-id to the top level of the component's template

### DIFF
--- a/templates/concept.html
+++ b/templates/concept.html
@@ -2,6 +2,7 @@
 <section data-trackable="concept"
 	aria-label="{{name}}"
 	{{#if responsiveGrids}}data-o-grid-colspan="{{responsiveGrids}}"{{/if}}
+    data-concept-id="{{id}}"
 	class="
 		topic-card__myft
 		{{#unless items.length}}topic-card--empty {{#if flags.myftGroupEmptyTopics}}myft-grouped-topic{{/if}}{{/unless}}


### PR DESCRIPTION
# Add data-concept-id to the top level of the component's template

## What
- Add data-concept-id to top level of component so this can be used for knowledge-builder persistence

 🐿 v2.11.0