### PR TITLE
Style browser visited state to match volt state

### DIFF
--- a/styles/_concept.scss
+++ b/styles/_concept.scss
@@ -51,7 +51,7 @@
 	color: oColorsGetPaletteColor('black');
 
 	&:visited {
-		color: getColor('black-80');
+		color: oColorsGetPaletteColor('black-50');
 	}
 
 	.topic-card__concept-article--read & {


### PR DESCRIPTION
myFT has two different visited states for article links:
* The browser's visited state
* A global/user visited state that is powered by a volt database
and allows visited states to be cross device.

This change aligns styling for these two states, which means users will see
their article as visited on their device even if the global/user state hasn't
been recorded in the database yet.

https://trello.com/c/196QDRkl/3311-visited-link-state-not-working-in-myft-feed

 🐿 v2.12.0