### PR TITLE
Add icon to audio content as per video content

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,7 @@
 @import 'n-myft-ui/myft/main';
 @import 'n-image/main';
 @import 'o-icons/main';
+@import './styles/mixins';
 @import './styles/myft-card';
 @import './styles/concept';
 @import './styles/classifier';

--- a/styles/_concept.scss
+++ b/styles/_concept.scss
@@ -35,14 +35,13 @@
 
 .topic-card__concept-article--video {
 	.topic-card__concept-article-link:before {
-		@include oIconsGetIcon('play', oColorsGetPaletteColor('white'), 15, $apply-width-height: false);
-		content: '';
-		width: 0.7em;
-		height: 0.7em;
-		min-width: 12px;
-		min-height: 12px;
-		margin-right: 0.15em;
-		background-color: oColorsGetPaletteColor('slate');
+		@include conceptArticleIcon('play');
+	}
+}
+
+.topic-card__concept-article--audio {
+	.topic-card__concept-article-link:before {
+		@include conceptArticleIcon('audio');
 	}
 }
 

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -1,0 +1,10 @@
+@mixin conceptArticleIcon($icon) {
+	@include oIconsGetIcon($icon, oColorsGetPaletteColor('white'), 15, $apply-width-height: false);
+	content: '';
+	width: 0.7em;
+	height: 0.7em;
+	min-width: 12px;
+	min-height: 12px;
+	margin-right: 0.15em;
+	background-color: oColorsGetPaletteColor('slate');
+}

--- a/templates/concept-article.html
+++ b/templates/concept-article.html
@@ -1,4 +1,4 @@
-<li class="topic-card__concept-article {{#ifEquals hasBeenRead true}}topic-card__concept-article--read{{/ifEquals}}{{#ifEquals type 'video'}} topic-card__concept-article--video{{/ifEquals}}">
+<li class="topic-card__concept-article {{#ifEquals hasBeenRead true}}topic-card__concept-article--read{{/ifEquals}}{{#ifEquals type 'video'}} topic-card__concept-article--video{{/ifEquals}}{{#ifEquals type 'audio'}} topic-card__concept-article--audio{{/ifEquals}}">
 	<a
 		class="topic-card__concept-article-link"
 		href="{{url}}{{#if ../conceptId}}?kbc={{../conceptId}}{{/if}}{{../referrerTracking}}"


### PR DESCRIPTION
Similar to how video contents gets a play icon, content with a type of 'audio' will get a speaker icon.

<img width="418" alt="Screenshot 2019-04-10 14 31 21" src="https://user-images.githubusercontent.com/295469/55882972-52e14980-5b9d-11e9-9cc6-7a86ea58e330.png">

 🐿 v2.12.3