### PR TITLE
Ttye/fix concept link underline

### DIFF
--- a/styles/_concept.scss
+++ b/styles/_concept.scss
@@ -1,6 +1,7 @@
 .topic-card__concept-link {
 	color: oColorsByName('black');
 	text-decoration: none;
+	border-bottom-width: 0;
 	word-wrap: break-word;
 
 	&:hover {
@@ -48,6 +49,7 @@
 .topic-card__concept-article-link {
 	color: oColorsByName('black');
 	text-decoration: none;
+	border-bottom-width: 0;
 
 	&:visited {
 		color: oColorsByName('black-50');

--- a/styles/_concept.scss
+++ b/styles/_concept.scss
@@ -1,7 +1,7 @@
 .topic-card__concept-link {
 	color: oColorsByName('black');
 	text-decoration: none;
-	border-bottom-width: 0;
+	border-bottom: 0;
 	word-wrap: break-word;
 
 	&:hover {
@@ -49,7 +49,7 @@
 .topic-card__concept-article-link {
 	color: oColorsByName('black');
 	text-decoration: none;
-	border-bottom-width: 0;
+	border: 0;
 
 	&:visited {
 		color: oColorsByName('black-50');


### PR DESCRIPTION
Udates 'topic-card__concept-article-link' to not render a border as underline. 
Required for origami cascade release of next-myft-page