### PR TITLE
Upgrade n-ui-foundations ^4.0.0 -> ^6.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "o-icons": "^6.0.0",
     "o-spacing": "^2.0.0",
     "o-tracking": "^2.0.3",
-    "n-myft-ui": "^21.0.2",
-    "n-ui-foundations": "^4.0.0"
+    "n-myft-ui": "^22.0.0",
+    "n-ui-foundations": "^6.0.0"
   }
 }

--- a/demos/demo.html
+++ b/demos/demo.html
@@ -1,4 +1,4 @@
-<div class="o-grid-container">
+<div class="o-grid-container o-grid-container--snappy">
 	<div class="o-grid-row">
 		{{#concepts}}
 			<div data-o-grid-colspan="12 M6 L4">


### PR DESCRIPTION
Jira card: https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1051&modal=detail&selectedIssue=CPP-89.

This PR upgrades the version of its `n-ui-foundations` bower dependency.

It also upgrades the version of its `n-myft-ui` bower dependency to a version that uses the same `n-ui-foundations` version (v6.0.0), as it too has a dependency on that package.

Re. this note in the Jira card:
> If the app relies on o-grid, bump this to v5.2.6 or higher in the `bower.json` file

This app currently lists `"o-grid": "^5.0.0"`, which results in v5.2.6 getting installed.

I have tested locally on the demo and it all looks 👍.