### PR TITLE
feat: adds custom slot to concept component

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,21 @@ Add the following line to your main sass file: `@import "n-topic-card/main";`.
 
 ## Usage
 
-Server-side
+### Server-side
 
 ```html
 {{> n-topic-card/templates/concept }}
 ```
 
-Client-side
+#### With custom slot
+
+```html
+{{#> n-topic-card/templates/concept withCustomSlot=true}}
+    <div>Some custom content you wish to inject at the bottom of the card before the footer</div>
+{{/ n-topic-card/templates/concept}}
+```
+
+### Client-side
 
 ```javascript
 const myftTemplate = require('../../../views/partials/myft.html');

--- a/demos/demo.html
+++ b/demos/demo.html
@@ -2,7 +2,14 @@
 	<div class="o-grid-row">
 		{{#concepts}}
 			<div data-o-grid-colspan="12 M6 L4">
-				{{> n-topic-card/templates/concept flags=@root.flags showPrioritiseButton=true}}
+				{{# if withCustomSlot }}
+					{{#> n-topic-card/templates/concept flags=@root.flags showPrioritiseButton=true
+														withCustomSlot=true}}
+						<span class="custom-slot-content">Some custom slot content</span>
+					{{/ n-topic-card/templates/concept}}
+				{{else}}
+					{{> n-topic-card/templates/concept flags=@root.flags showPrioritiseButton=true}}
+				{{/if}}
 			</div>
 		{{/concepts}}
 	</div>

--- a/demos/fixtures.json
+++ b/demos/fixtures.json
@@ -87,6 +87,30 @@
       "id": "4",
       "name": "Concept with no articles",
       "url": "/4"
+    },
+    {
+      "id": "5",
+      "name": "Unfollowed concept with articles",
+      "url": "/1",
+      "items": [
+        {
+          "title": "Example article 1",
+          "url": "/"
+        },
+        {
+          "title": "Example article 2",
+          "url": "/"
+        },
+        {
+          "title": "Example article 3",
+          "url": "/"
+        },
+        {
+          "title": "Example article 4",
+          "url": "/"
+        }
+      ],
+      "withCustomSlot": true
     }
   ]
 }

--- a/styles/_myft-card.scss
+++ b/styles/_myft-card.scss
@@ -40,6 +40,10 @@
 	margin: 0;
 }
 
+.topic-card__custom-slot {
+	flex: 1 0 auto;
+}
+
 .topic-card__myft-footer {
 	margin-top: oSpacingByName('s1');
 	padding-top: oSpacingByName('s2');

--- a/templates/concept.html
+++ b/templates/concept.html
@@ -48,7 +48,13 @@
 				{{/unless}}
 			</div>
 		{{/if}}
-
+		{{#if @partial-block}}
+		{{#if withCustomSlot}}
+				<div class="topic-card__custom-slot">
+						{{> @partial-block }}
+				</div>
+		{{/if}}
+		{{/if}}
 		<footer class="topic-card__myft-footer">
 			{{#if excessItems.length }}
 			<p class="topic-card__excess">


### PR DESCRIPTION
# feat: adds custom slot to concept component

## What
- adds optional custom slot to concept component
- adds documentation in readme for custom slot
- adds example of custom slot to demo

## Why
FT Community have a plan to add events to myFT (Figma Screenshot below). On the myFT topic view, this takes the form of a small concept specific event slice that will be the bottom of the topic cards (similar to where the topic tracker slice used to be a couple of years back). By enabling topic-cards to optionally have a custom-slot, we can add the ui for this slice server side in myFT page app.

<img width="184" alt="Screenshot 2021-09-15 at 13 55 16" src="https://user-images.githubusercontent.com/11778762/133437147-6946f4ca-3578-4ae2-b23e-5e48448ef94d.png">
