### PR TITLE
Do not use abbreviated date/time format in topic cards.

### DIFF
--- a/styles/_concept.scss
+++ b/styles/_concept.scss
@@ -77,6 +77,7 @@
 	margin-bottom: 0;
 	color: oColorsByName('black-60');
 	text-transform: uppercase;
+	white-space: nowrap;
 }
 
 .topic-card__concept-follow {

--- a/templates/concept-article.html
+++ b/templates/concept-article.html
@@ -14,7 +14,7 @@
 			<time
 				data-o-component="o-date"
 				class="o-date"
-				data-o-date-format="time-ago-abbreviated"
+				data-o-date-format="time-ago-no-seconds"
 				datetime="{{publishedDate}}">
 			</time>
 		</span>


### PR DESCRIPTION
E.g. use "a day ago" over "1d ago". The abbreviated form is deprecated. This is the last place it us used. This commit also updates the date/time style so it wraps onto a new line instead of breaking.

We came across this due to an accessibility audit: https://github.com/Financial-Times/origami/issues/203

before:
<img width="397" alt="before" src="https://user-images.githubusercontent.com/10405691/139471076-fe7c6a91-48ed-42ae-a577-84688ac0784e.png">

after:
<img width="395" alt="after" src="https://user-images.githubusercontent.com/10405691/139471069-1f5b23d5-b42d-4c55-9686-2a9f6df6ce90.png">

This aligns with other ft pages, for example the beta homepage:
![Screenshot 2021-10-29 at 15 25 10](https://user-images.githubusercontent.com/10405691/139471142-a051a573-cb61-46f3-8441-5eb9c033f8e3.png)


