### PR TITLE
CON-2095: Add possibility to specify topic on a card without articles

### DIFF
--- a/demos/fixtures.json
+++ b/demos/fixtures.json
@@ -90,6 +90,12 @@
     },
     {
       "id": "5",
+      "name": "Concept with no articles and a topic",
+      "url": "/4",
+      "nTopicCardEmptyTopic": "Topic"
+    },
+    {
+      "id": "6",
       "name": "Unfollowed concept with articles",
       "url": "/1",
       "items": [

--- a/templates/concept.html
+++ b/templates/concept.html
@@ -42,7 +42,12 @@
 					</p>
 					<p class="topic-card__concept-empty">
 						<a class="topic-card__concept-empty-link" data-trackable="empty-link" href={{url}}>
-							See more on this topic
+							See more on
+							{{#if nTopicCardEmptyTopic}}
+								the topic {{nTopicCardEmptyTopic}}
+							{{else}}
+								this topic
+							{{/if}}
 						</a>
 					</p>
 				{{/unless}}


### PR DESCRIPTION
# Issue 

[DAC JIRA](https://financialtimes.atlassian.net/browse/CON-2095):  
The problem is that some cards with no articles display a link "See more on this topic" but this is not accessible as it doesn't express what is the topic.  

# Solution

To be able to explicit the topic, we add a nTopicCardEmptyTopic.   

A card with nTopicCardEmptySubject set up is added in the demo for test purposes. 

# Screenshot

<img width="805" alt="Screenshot 2022-11-14 at 19 38 11" src="https://user-images.githubusercontent.com/107469842/201750873-8dcbd456-7c28-422c-b97e-c1fab1fdac9a.png">
