### PR TITLE
CON-2095: Using preflabel/name for the link in empty n-topic-card

### DIFF
--- a/demos/fixtures.json
+++ b/demos/fixtures.json
@@ -92,7 +92,7 @@
       "id": "5",
       "name": "Concept with no articles and a topic",
       "url": "/4",
-      "nTopicCardEmptyTopic": "Topic"
+      "nTopicCardEmptyTopic": true
     },
     {
       "id": "6",

--- a/templates/concept.html
+++ b/templates/concept.html
@@ -43,8 +43,8 @@
 					<p class="topic-card__concept-empty">
 						<a class="topic-card__concept-empty-link" data-trackable="empty-link" href={{url}}>
 							See more on
-							{{#if nTopicCardEmptyTopic}}
-								the topic {{nTopicCardEmptyTopic}}
+							{{#if nTopicCardEmptyTopic }}
+								the topic {{#if prefLabel}}{{prefLabel}}{{else}}{{name}}{{/if}}
 							{{else}}
 								this topic
 							{{/if}}


### PR DESCRIPTION
In the previous release, I thought that we could just use a card that has no article and set the topic of the card from the app using the n-topic-card. When I tried to use that release in **next-myft-page**, I realised that I had no access to the topic from [there](https://github.com/Financial-Times/next-myft-page/blob/main/views/universal/v2/feed/cards.html#L44). 

Instead, I kept the `nTopicCardEmptyTopic` but as a boolean (to make sure other implementation are still working) and use the existing prefLabel or name of the n-topic-card itself. 

# Test and screenshot

This time, thanks to Jose who showed me how to use `npm link`, I was able to test that in context, and not just in the demo file. Here is the implementation of that change : 

| Old implementation  | nTopicCardEmptyTopic set to true | nTopicCardEmptyTopic set to false |
| - | - | - |
|<img width="828" alt="Screenshot 2022-11-15 at 16 51 14" src="https://user-images.githubusercontent.com/107469842/201980190-6b31afc3-0121-4b8a-8340-049f5ddbce43.png">|<img width="875" alt="Screenshot 2022-11-16 at 12 28 27" src="https://user-images.githubusercontent.com/107469842/202180864-fc39133d-99c1-4187-84d3-62f755a1ef67.png">|<img width="847" alt="Screenshot 2022-11-15 at 17 16 18" src="https://user-images.githubusercontent.com/107469842/201984099-a22a6e01-2a33-4a99-ba30-d2eb7a76dc7c.png">|