### PR TITLE
CON-2095: Add topic name to footer of concept cards

### DIFF
--- a/demos/fixtures.json
+++ b/demos/fixtures.json
@@ -116,6 +116,20 @@
           "url": "/"
         }
       ],
+      "excessItems": [
+        {
+          "title": "Example article 5",
+          "url": "/"
+        },
+        {
+          "title": "Example article 6",
+          "url": "/"
+        },
+        {
+          "title": "Example article 7",
+          "url": "/"
+        }
+      ],
       "withCustomSlot": true
     }
   ]

--- a/templates/concept.html
+++ b/templates/concept.html
@@ -63,7 +63,7 @@
 		<footer class="topic-card__myft-footer">
 			{{#if excessItems.length }}
 			<p class="topic-card__excess">
-				<a class="topic-card__excess-link" href="{{url}}" data-trackable="excess-stories-link" aria-label="{{ excessItems.length }} more stor{{#ifEquals excessItems.length 1 }}y{{else}}ies{{/ifEquals}}">
+				<a class="topic-card__excess-link" href="{{url}}" data-trackable="excess-stories-link" aria-label="{{ excessItems.length }} more stor{{#ifEquals excessItems.length 1 }}y{{else}}ies{{/ifEquals}} on {{#if prefLabel}}{{prefLabel}}{{else}}{{name}}{{/if}}">
 					{{ excessItems.length }} more stor{{#ifEquals excessItems.length 1 }}y{{else}}ies{{/ifEquals}}
 				</a>
 			</p>


### PR DESCRIPTION
# The Issue
[DAC JIRA](https://financialtimes.atlassian.net/browse/CON-2095):  
The link in the footer of the concept card is not descriptive enough. It say "3 more stories" but if you are using a screen reader, you may not know what it is about anymore. 

# The solution

Adding the name or prefLabel of the topic in the footer, as the aria-label. Now it says '666 more stories on Twitter inc' when using a screen reader. 

NB: this is only the case for when there is extra stories. If the footer says '0 more stories', it is not a link, it does not need to get the extra info. 

# The results

(Ran the tests, including pa11y)

It looks as it was before. I added an example of the 'more stories' thingy in the demo to test is with screen reader and.. it worked fine. 

<img width="806" alt="Screenshot 2022-11-23 at 14 12 13" src="https://user-images.githubusercontent.com/107469842/203571912-225bcb26-91e9-4c70-a17e-815a1a76b796.png">
