### PR TITLE
ug-1004 widen n-myft-ui peer dependency to include new release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "npm": "7.x"
       },
       "peerDependencies": {
-        "@financial-times/n-myft-ui": "^28.0.6",
+        "@financial-times/n-myft-ui": "^28.3.0 || 29.x",
         "n-ui-foundations": "^9.0.0"
       }
     },
@@ -937,9 +937,9 @@
       "peer": true
     },
     "node_modules/@financial-times/n-myft-ui": {
-      "version": "28.0.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-28.0.6.tgz",
-      "integrity": "sha512-YNQGOF2th3DXsc4iq2eHAkIkrzF6M1Obkx7lqe+skbhu5mXELfVEgS5swga0hNBtMKQi3pPQE6g8FGtCA+/+KQ==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-29.0.0.tgz",
+      "integrity": "sha512-l226s/C9RR36teVSxNgja0kkEbXgeXBW0dFOV4zckta7JXJFAJ0aCnlNxO/a2Kp+CkeZ/cvWR4I7m2qbUSDXUA==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
@@ -948,7 +948,7 @@
         "form-serialize": "^0.7.2",
         "ftdomdelegate": "^4.0.6",
         "js-cookie": "^2.2.1",
-        "next-myft-client": "^10.1.0",
+        "next-myft-client": "^10.3.0",
         "next-session-client": "^4.0.0",
         "superstore-sync": "^2.1.1"
       },
@@ -965,7 +965,7 @@
         "@financial-times/o-normalise": "^3.0.0",
         "@financial-times/o-overlay": "^4.0.0",
         "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-tooltip": "^5.0.0",
+        "@financial-times/o-tooltip": "^5.2.4",
         "@financial-times/o-topper": "^5.2.3",
         "n-ui-foundations": "^9.0.0"
       }
@@ -1243,9 +1243,9 @@
       }
     },
     "node_modules/@financial-times/o-tooltip": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.2.tgz",
-      "integrity": "sha512-JUklwHvNmEFXfqjc6Ft7jV5Rc3cTfqBbcnexMCOvWTr8BE3Xidbg6/VumLKhmS+MTmG4NFl5EgP4Kt2hLrAa1Q==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.4.tgz",
+      "integrity": "sha512-GXC320/zwTNvacG4PCHSwGBPb+3eWMw7pePUAw41iJ70Wjwy+H9aGbbQikWOiBCiSb6BohwImWOJ6RR0g1dReg==",
       "peer": true,
       "dependencies": {
         "ftdomdelegate": "^4.0.6"
@@ -1254,6 +1254,7 @@
         "npm": "^7 || ^8"
       },
       "peerDependencies": {
+        "@financial-times/o-brand": "^4.2.1",
         "@financial-times/o-grid": "^6.0.0",
         "@financial-times/o-icons": "^7.0.1",
         "@financial-times/o-normalise": "^3.0.0",
@@ -5828,9 +5829,9 @@
       }
     },
     "node_modules/next-myft-client": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.2.0.tgz",
-      "integrity": "sha512-tmCn7kleYGgSd+0kEhwUketVhm0c0Ci87yFODaGPESK7AT+RmTxdC9QA4oSl8Q9izAJz4dPAgC07fPcz2nr2aw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.4.0.tgz",
+      "integrity": "sha512-So5endIOia+I9bqP18kg0iu7htoakl8m78gG7KYj9O6okgJ6frXRB5mXhYYhUkBqjtap60+vxFqa9BdI4jnN7g==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {
@@ -10177,9 +10178,9 @@
       "peer": true
     },
     "@financial-times/n-myft-ui": {
-      "version": "28.0.6",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-28.0.6.tgz",
-      "integrity": "sha512-YNQGOF2th3DXsc4iq2eHAkIkrzF6M1Obkx7lqe+skbhu5mXELfVEgS5swga0hNBtMKQi3pPQE6g8FGtCA+/+KQ==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-myft-ui/-/n-myft-ui-29.0.0.tgz",
+      "integrity": "sha512-l226s/C9RR36teVSxNgja0kkEbXgeXBW0dFOV4zckta7JXJFAJ0aCnlNxO/a2Kp+CkeZ/cvWR4I7m2qbUSDXUA==",
       "peer": true,
       "requires": {
         "date-fns": "2.16.1",
@@ -10187,7 +10188,7 @@
         "form-serialize": "^0.7.2",
         "ftdomdelegate": "^4.0.6",
         "js-cookie": "^2.2.1",
-        "next-myft-client": "^10.1.0",
+        "next-myft-client": "^10.3.0",
         "next-session-client": "^4.0.0",
         "superstore-sync": "^2.1.1"
       }
@@ -10345,9 +10346,9 @@
       "requires": {}
     },
     "@financial-times/o-tooltip": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.2.tgz",
-      "integrity": "sha512-JUklwHvNmEFXfqjc6Ft7jV5Rc3cTfqBbcnexMCOvWTr8BE3Xidbg6/VumLKhmS+MTmG4NFl5EgP4Kt2hLrAa1Q==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.4.tgz",
+      "integrity": "sha512-GXC320/zwTNvacG4PCHSwGBPb+3eWMw7pePUAw41iJ70Wjwy+H9aGbbQikWOiBCiSb6BohwImWOJ6RR0g1dReg==",
       "peer": true,
       "requires": {
         "ftdomdelegate": "^4.0.6"
@@ -13774,9 +13775,9 @@
       }
     },
     "next-myft-client": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.2.0.tgz",
-      "integrity": "sha512-tmCn7kleYGgSd+0kEhwUketVhm0c0Ci87yFODaGPESK7AT+RmTxdC9QA4oSl8Q9izAJz4dPAgC07fPcz2nr2aw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.4.0.tgz",
+      "integrity": "sha512-So5endIOia+I9bqP18kg0iu7htoakl8m78gG7KYj9O6okgJ6frXRB5mXhYYhUkBqjtap60+vxFqa9BdI4jnN7g==",
       "peer": true,
       "requires": {
         "black-hole-stream": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "n-ui-foundations": "^9.0.0",
-    "@financial-times/n-myft-ui": "^28.3.0"
+    "@financial-times/n-myft-ui": "^28.3.0 || 29.x"
   },
   "engines": {
     "node": "14.x || 16.x",


### PR DESCRIPTION
We've release version 29.0.0 of n-myft-ui, which we need to use in a number of apps, including next-stream-page, which is also using n-topic-card. This PR increases the peer dependency to also allow anything in v29.x.

[n-myft-ui v29.0.0 release notes](https://github.com/Financial-Times/n-myft-ui/releases/tag/v29.0.0)